### PR TITLE
update order and names of input variables; some spell-checking

### DIFF
--- a/PySBA.py
+++ b/PySBA.py
@@ -41,17 +41,18 @@ class PySBA:
                     next 3 components form a translation vector,
                     then a focal distance and two distortion parameters.
 
-            points_3d with shape (n_points, 3)
+            points3D with shape (n_points, 3)
                     contains initial estimates of point coordinates in the world frame.
 
-            camera_ind with shape (n_observations,)
+            points2D with shape (n_observations, 2)
+                    contains measured 2-D coordinates of points projected on images in each observation.
+
+            cameraIndices with shape (n_observations,)
                     contains indices of cameras (from 0 to n_cameras - 1) involved in each observation.
 
-            point_ind with shape (n_observations,)
-                    contatins indices of points (from 0 to n_points - 1) involved in each observation.
+            point2DIndices with shape (n_observations,)
+                    contains indices of points (from 0 to n_points - 1) involved in each observation.
 
-            points_2d with shape (n_observations, 2)
-                    contains measured 2-D coordinates of points projected on images in each observations.
         """
         self.cameraArray = cameraArray
         self.points3D = points3D


### PR DESCRIPTION
a couple of the names of variables in the entry point description were outdated because they were pulled directly from the scipy documentation. I went ahead and updated those (and fixed a couple typos as well)